### PR TITLE
Add build and upload (for PyPI) steps to CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -61,7 +61,7 @@ jobs:
                 name: distributions
                 path: dist/
     upload:
-        #if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
         runs-on: ubuntu-20.04
         needs:
           - build
@@ -73,5 +73,4 @@ jobs:
           - uses: actions/download-artifact@v3
             with:
                 name: distributions
-          - if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
-            uses: pypa/gh-action-pypi-publish@release/v1
+          - uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -61,7 +61,7 @@ jobs:
                 name: distributions
                 path: dist/
     upload:
-        #if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
         runs-on: ubuntu-20.04
         needs:
           - build
@@ -74,5 +74,4 @@ jobs:
             with:
                 name: distributions
                 path: dist/
-          - run: ls -l
-          #- uses: pypa/gh-action-pypi-publish@release/v1
+          - uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -73,4 +73,5 @@ jobs:
           - uses: actions/download-artifact@v3
             with:
                 name: distributions
-          - run: ls -l
+          - if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+            uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -61,7 +61,7 @@ jobs:
                 name: distributions
                 path: dist/
     upload:
-        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+        #if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
         runs-on: ubuntu-20.04
         needs:
           - build
@@ -74,4 +74,5 @@ jobs:
             with:
                 name: distributions
                 path: dist/
-          - uses: pypa/gh-action-pypi-publish@release/v1
+          - run: ls -l
+          #- uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -73,4 +73,5 @@ jobs:
           - uses: actions/download-artifact@v3
             with:
                 name: distributions
+                path: dist/
           - uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -43,3 +43,34 @@ jobs:
           - run: pip check
           - run: coverage run --source=rest_framework_filters/ --branch manage.py test
           - run: coverage report --show-missing
+    build:
+        runs-on: ubuntu-20.04
+        needs:
+          - lint
+          - test
+        steps:
+          - uses: actions/checkout@v2
+          - uses: actions/setup-python@v2
+            with:
+                python-version: 3.9
+          - run: pip install -U pip setuptools wheel
+          - run: pip install build
+          - run: pyproject-build .
+          - uses: actions/upload-artifact@v3
+            with:
+                name: distributions
+                path: dist/
+    upload:
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+        runs-on: ubuntu-20.04
+        needs:
+          - build
+        permissions:
+            # https://docs.pypi.org/trusted-publishers/using-a-publisher/
+            id-token: write
+        steps:
+          - uses: actions/checkout@v2
+          - uses: actions/download-artifact@v3
+            with:
+                name: distributions
+          - uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -73,5 +73,4 @@ jobs:
           - uses: actions/download-artifact@v3
             with:
                 name: distributions
-          - if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
-            uses: pypa/gh-action-pypi-publish@release/v1
+          - run: ls -l

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -61,7 +61,7 @@ jobs:
                 name: distributions
                 path: dist/
     upload:
-        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+        #if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
         runs-on: ubuntu-20.04
         needs:
           - build
@@ -73,4 +73,5 @@ jobs:
           - uses: actions/download-artifact@v3
             with:
                 name: distributions
-          - uses: pypa/gh-action-pypi-publish@release/v1
+          - if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+            uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
The `build` job always runs. The `upload` job only runs on tagged commits.